### PR TITLE
Make clear tracks work with linked tracks

### DIFF
--- a/LiveEnhancementSuite.ahk
+++ b/LiveEnhancementSuite.ahk
@@ -1557,7 +1557,7 @@ WinGetTitle, WinTitle, ahk_id %guideUnderCursor%
 if(InStr(WinTitle, "Ableton Live 11") != 0){
 	Click, Right
 	sleep, 20
-	SendInput {up 9}{enter}
+	SendInput {up 1}{down 13}{enter}
 	sleep, 5
 	sendinput {delete}
 }


### PR DESCRIPTION
As the track menu structure in Live11 changes when multiple tracks are selected (enables Link Tracks) or if a track is already linked (enables Unlink Track), the logic added recently for clear tracks does not work in those cases. 

I think I can see why just using "down" doesn't work reliably, but as far as I can tell you can get to "Select Track Content" reliably by first going up one item to get you to the last item on the menu and then going down the required number of times. This way, clear tracks works with multiple selected tracks and with linked tracks.

I hope this is helpful.
-stephen