### PR TITLE
Make quickmarker work again in Live 11

### DIFF
--- a/LiveEnhancementSuite.ahk
+++ b/LiveEnhancementSuite.ahk
@@ -1531,12 +1531,16 @@ gosub, VSTredo
 Return
 
 quickmarker:
-WinGetActiveTitle, wintitleoutput
-if !(InStr(title, "Live 9", CaseSensitive := false) = 0){
-WinMenuSelectItem,,, 3&, 13&
+MouseGetPos,,,guideUnderCursor
+WinGetTitle, WinTitle, ahk_id %guideUnderCursor%
+if (InStr(WinTitle, "Live 9", CaseSensitive := false) != 0){
+	WinMenuSelectItem,,, 3&, 13&
 }
-Else{
-WinMenuSelectItem,,, 3&, 14&
+else if(InStr(WinTitle, "Ableton Live 11") != 0){
+	WinMenuSelectItem,,, 3&, 20&
+}
+else if(InStr(WinTitle, "Ableton") != 0){
+	WinMenuSelectItem,,, 3&, 14&
 }
 return
 


### PR DESCRIPTION
This commit modifes the quickmarker routine to:

- get the window title in the same way as the other routines and use
  the correct output variable in the subsequent tests
- make the menu selection work in Live 11